### PR TITLE
Create /alexa scope

### DIFF
--- a/lib/french_toast_server/web/router.ex
+++ b/lib/french_toast_server/web/router.ex
@@ -12,4 +12,10 @@ defmodule FrenchToastServer.Web.Router do
 
     resources "/statuses", StatusController, only: [:index, :show]
   end
+
+  scope "/alexa", FrenchToastServer.Web do
+    pipe_through :api
+
+    post "/", AlexaController, :post
+  end
 end


### PR DESCRIPTION
Reach Alexa at `POST /alexa`. Previously Alexa was scoped through `v1` so the endpoint was `POST /v1/alexa`.

**Example Request (from Amazon)**
```http
POST /alexa HTTP/1.1
Host: localhost:4000
Content-Type: application/json
Cache-Control: no-cache
Postman-Token: 81f2db0c-3939-7de8-0435-2a0afdcd2fe3

{
  "session": {
    "sessionId": "SessionId.3571e3c4-a28a-4917-bd69-86d6b438204b",
    "application": {
      "applicationId": "amzn1.ask.skill.09cef3be-ff35-497e-ae4c-baf37ec919ac"
    },
    "attributes": {},
    "user": {
      "userId": "amzn1.ask.account.AGUYHBBZWHT5UXTSN4J2T6Q3SXQEE7PAZVR4Z26NHE7IUZDOX5MIK64DJIKMQCEK4NT7NTPHQCLNETLNL2JLZPKFTP6U4IP3WLHNAEZKLO37BXUR24MDKKD2TQREMTWFVOOY5WWLC7CK6TSE3IZNIIAIR7DN745CMPIA67V32X2Z4TT4HTDBOE542XKOZPMYW4H7MSSLOGJIJ3Q"
    },
    "new": true
  },
  "request": {
    "type": "IntentRequest",
    "requestId": "EdwRequestId.ef83433e-ea2c-4df3-841c-7452fb696a8c",
    "locale": "en-US",
    "timestamp": "2017-04-30T20:14:42Z",
    "intent": {
      "name": "GetHelloToastIntent",
      "slots": {}
    }
  },
  "version": "1.0"
}
```
**Example Response**
```json
{
  "version": "1.0",
  "sessionAttributes": {},
  "response": {
    "shouldEndSession": true,
    "outputSpeech": {
      "type": "PlainText",
      "text": "According to UniversalHub, the current French Toast Alert Level is low."
    }
  }
}
```
