### PR TITLE
GET /current-status and GET /status-history

### DIFF
--- a/lib/french_toast_server/web/controllers/current_status_controller.ex
+++ b/lib/french_toast_server/web/controllers/current_status_controller.ex
@@ -1,0 +1,12 @@
+defmodule FrenchToastServer.Web.CurrentStatusController do
+  use FrenchToastServer.Web, :controller
+
+  alias FrenchToastServer.Data
+
+  action_fallback FrenchToastServer.Web.FallbackController
+
+  def show(conn, _params) do
+    status = Data.get_current_status
+    render(conn, "show.json", status: status)
+  end
+end

--- a/lib/french_toast_server/web/router.ex
+++ b/lib/french_toast_server/web/router.ex
@@ -9,6 +9,7 @@ defmodule FrenchToastServer.Web.Router do
     pipe_through :api
 
     resources "/statuses", StatusController, only: [:index, :show]
+    get "/current-status", CurrentStatusController, :show
   end
 
   scope "/alexa", FrenchToastServer.Web do

--- a/lib/french_toast_server/web/router.ex
+++ b/lib/french_toast_server/web/router.ex
@@ -9,6 +9,7 @@ defmodule FrenchToastServer.Web.Router do
     pipe_through :api
 
     resources "/statuses", StatusController, only: [:index, :show]
+    get "/status-history", StatusController, :index
     get "/current-status", CurrentStatusController, :show
   end
 

--- a/lib/french_toast_server/web/router.ex
+++ b/lib/french_toast_server/web/router.ex
@@ -8,8 +8,6 @@ defmodule FrenchToastServer.Web.Router do
   scope "/v1", FrenchToastServer.Web do
     pipe_through :api
 
-    post "/alexa", AlexaController, :post
-
     resources "/statuses", StatusController, only: [:index, :show]
   end
 

--- a/lib/french_toast_server/web/views/current_status_view.ex
+++ b/lib/french_toast_server/web/views/current_status_view.ex
@@ -1,0 +1,8 @@
+defmodule FrenchToastServer.Web.CurrentStatusView do
+  use FrenchToastServer.Web, :view
+  alias FrenchToastServer.Web.CurrentStatusView
+
+  def render("show.json", %{status: status}) do
+    %{id: status.id, created_at: status.inserted_at, level: status.data_level.name}
+  end
+end


### PR DESCRIPTION
## Current Status
- I decided to create a new controller instead of adding an action to StatusController to stay RESTful. I am not sure if that was the right decision.

**Example Request**
```http
GET /v1/current-status HTTP/1.1
Host: localhost:4000
Content-Type: application/json
Cache-Control: no-cache
Postman-Token: ab368c38-41ec-9422-f754-549efd9dcc4e
```
**Example Response**
```json
{
  "level": "low",
  "id": 35,
  "created_at": "2017-04-30T20:05:16.458634"
}
```

## Status History (displays statuses index)
**Example Request**
```http
GET /v1/status-history HTTP/1.1
Host: localhost:4000
Content-Type: application/json
Cache-Control: no-cache
Postman-Token: 4339d60e-b0c0-c8f3-236b-c9310e1e2e11
```
**Example Response**
```json
{
  "data": [
    {
      "level": "high",
      "id": 32,
      "created_at": "2017-04-30T20:00:38.792379"
    },
    {
      "level": "elevated",
      "id": 33,
      "created_at": "2017-04-30T20:00:44.568547"
    },
    {
      "level": "low",
      "id": 34,
      "created_at": "2017-04-30T20:04:16.360435"
    },
    {
      "level": "low",
      "id": 35,
      "created_at": "2017-04-30T20:05:16.458634"
    }
  ]
}
```